### PR TITLE
convert recognized types to properties

### DIFF
--- a/jsonobject/__init__.py
+++ b/jsonobject/__init__.py
@@ -1,8 +1,11 @@
 from base import JsonObject, JsonArray
-from properties import *
+from .properties import *
+import properties
 __all__ = [
     'IntegerProperty', 'FloatProperty', 'StringProperty', 'BooleanProperty',
     'DateProperty', 'DateTimeProperty',
     'ObjectProperty', 'ListProperty',
     'JsonObject', 'JsonArray',
 ]
+
+JsonObjectMeta.properties_module = properties

--- a/jsonobject/properties.py
+++ b/jsonobject/properties.py
@@ -1,5 +1,5 @@
 import datetime
-from jsonobject.base import AssertTypeProperty, JsonProperty, JsonArray, JsonObject
+from jsonobject.base import AssertTypeProperty, JsonProperty, JsonArray, JsonObject, JsonObjectMeta
 import inspect
 
 
@@ -85,19 +85,24 @@ class ListProperty(ObjectProperty):
             wrapped.extend(obj)
             return self.unwrap(wrapped)
 
+
 TYPE_TO_PROPERTY = {
     int: IntegerProperty,
     basestring: StringProperty,
+    bool: BooleanProperty,
+    float: FloatProperty,
+    datetime.date: DateProperty,
+    datetime.datetime: DateTimeProperty,
 }
 
 
-def type_to_property(obj_type):
+def type_to_property(obj_type, *args, **kwargs):
     if issubclass(obj_type, JsonObject):
-        return ObjectProperty(obj_type)
+        return ObjectProperty(obj_type, *args, **kwargs)
     elif obj_type in TYPE_TO_PROPERTY:
-        return TYPE_TO_PROPERTY[obj_type]()
+        return TYPE_TO_PROPERTY[obj_type](*args, **kwargs)
     else:
         for key, value in TYPE_TO_PROPERTY.items():
             if issubclass(obj_type, key):
-                return value()
+                return value(*args, **kwargs)
         raise TypeError('Type {0} not recognized'.format(obj_type))

--- a/tests.py
+++ b/tests.py
@@ -30,6 +30,7 @@ class Person(Document):
 
 
 class FamilyMember(Person):
+    base_doc = 'Person'
     brothers = ListProperty(lambda: Person)
 
 
@@ -113,6 +114,7 @@ class JsonObjectTestCase(unittest2.TestCase):
         p = FamilyMember()
         self.assertEqual(p.to_json(), {
             'doc_type': 'FamilyMember',
+            'base_doc': 'Person',
             'first_name': None,
             'last_name': None,
             'brothers': [],


### PR DESCRIPTION
``` python
class Foo(JsonObject):
    string = 'my value'
```

now sets `string` to be `StringProperty(default='my value')`
