### PR TITLE
allow accessing property descriptor from class

### DIFF
--- a/jsonobject/base.py
+++ b/jsonobject/base.py
@@ -54,7 +54,10 @@ class JsonProperty(object):
 
     def __get__(self, instance, owner):
         assert self.name in instance
-        return instance[self.name]
+        if instance:
+            return instance[self.name]
+        else:
+            return self
 
     def __set__(self, instance, value):
         instance[self.name] = value


### PR DESCRIPTION
MyJsonObject.my_property should return the descriptor instead of crashing
