### PR TITLE
allow passing in a property as container property item types

### DIFF
--- a/jsonobject/base.py
+++ b/jsonobject/base.py
@@ -106,8 +106,8 @@ class JsonContainerProperty(JsonProperty):
         from convert import ALLOWED_PROPERTY_TYPES
         if inspect.isfunction(item_type):
             item_type = item_type()
-        else:
-            item_type = item_type
+        if hasattr(item_type, '_type'):
+            item_type = item_type._type
         self.item_type = item_type
         if item_type and item_type not in tuple(ALLOWED_PROPERTY_TYPES) \
                 and not issubclass(item_type, JsonObject):


### PR DESCRIPTION
now `ListProperty(int)` and `ListProperty(IntegerProperty)` are both acceptable
(the former is still preferred)
