### PR TITLE
allow accessing property descriptor from class

### DIFF
--- a/jsonobject/base.py
+++ b/jsonobject/base.py
@@ -53,8 +53,11 @@ class JsonProperty(object):
         return self.wrap(value)
 
     def __get__(self, instance, owner):
-        assert self.name in instance
-        return instance[self.name]
+        if instance:
+            assert self.name in instance
+            return instance[self.name]
+        else:
+            return self
 
     def __set__(self, instance, value):
         instance[self.name] = value

--- a/test/tests.py
+++ b/test/tests.py
@@ -299,6 +299,13 @@ class JsonObjectTestCase(unittest2.TestCase):
             }
         })
 
+    def test_access_to_descriptor(self):
+        p = StringProperty()
+        class Foo(JsonObject):
+            string = p
+
+        self.assertIs(Foo.string, p)
+
 
 class LazyValidationTest(unittest2.TestCase):
 


### PR DESCRIPTION
MyJsonObject.my_property should return the descriptor instead of crashing
