### PR TITLE
fix type_to_property(basestring)

### DIFF
--- a/jsonobject/convert.py
+++ b/jsonobject/convert.py
@@ -42,6 +42,7 @@ MAP_TYPES_PROPERTIES = {
     datetime.time: properties.TimeProperty,
     str: properties.StringProperty,
     unicode: properties.StringProperty,
+    basestring: properties.StringProperty,
     bool: properties.BooleanProperty,
     int: properties.IntegerProperty,
     long: properties.IntegerProperty,


### PR DESCRIPTION
so that you can use `ListProperty(StringProperty)` even though that's not preferred
