### PR TITLE
add `exact` option for time properties

### DIFF
--- a/jsonobject/base.py
+++ b/jsonobject/base.py
@@ -207,6 +207,10 @@ class AbstractDateProperty(JsonProperty):
 
     _type = None
 
+    def __init__(self, exact=False, *args, **kwargs):
+        super(AbstractDateProperty, self).__init__(*args, **kwargs)
+        self.exact = exact
+
     def wrap(self, obj):
         try:
             if not isinstance(obj, basestring):

--- a/test/tests.py
+++ b/test/tests.py
@@ -678,6 +678,17 @@ class User(JsonObject):
     tags = ListProperty(unicode)
 
 
+class TestExactDateTime(unittest2.TestCase):
+    def test_exact(self):
+        class DateObj(JsonObject):
+            date = DateTimeProperty(exact=True)
+        import datetime
+        date = datetime.datetime.utcnow()
+        date_obj = DateObj(date=date)
+        self.assertEqual(date_obj.date, date)
+        self.assertEqual(date_obj.to_json()['date'], date.isoformat() + 'Z')
+
+
 class TestReadmeExamples(unittest2.TestCase):
     def test(self):
         import datetime


### PR DESCRIPTION
- includes microseconds
- accepts only exact iso format

``` python
class Foo(JsonObject):
    date = DateTimeProperty(exact=True)
```
