### PR TITLE
Fix Travis badge that was broken from move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jsonobject
 
-[![Build Status](https://travis-ci.org/dannyroberts/jsonobject.png)](https://travis-ci.org/dannyroberts/jsonobject)
+[![Build Status](https://travis-ci.org/dimagi/jsonobject.png)](https://travis-ci.org/dimagi/jsonobject)
 
 A python library for handling deeply nested JSON objects
 as well-schema'd python objects.


### PR DESCRIPTION
It looks like the repository was moved from Daniel's user to the Dimagi organization. The readme wasn't updated to reflect this.