### PR TITLE
Exclude if empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,11 @@ Here is a complete list of properties:
   (Note that currently this is at odds with the parameter's name,
   since the condition is that it is falsey, not that it is `None`).
 
+- `exclude_if_empty`
+
+  Defaults to `False`. When set to true, this property will be excluded
+  from the JSON output when its value is None.
+
 - `validators`
 
   A single validator function or list of validator functions.

--- a/jsonobject/base_properties.py
+++ b/jsonobject/base_properties.py
@@ -11,15 +11,14 @@ else:
     def function_name(f):
         return f.func_name
 
-
 class JsonProperty(object):
 
     default = None
     type_config = None
 
     def __init__(self, default=Ellipsis, name=None, choices=None,
-                 required=False, exclude_if_none=False, validators=None,
-                 verbose_name=None, type_config=None):
+                 required=False, exclude_if_none=False, exclude_if_empty=False,
+                 validators=None, verbose_name=None, type_config=None):
         validators = validators or ()
         self.name = name
         if default is Ellipsis:
@@ -36,7 +35,10 @@ class JsonProperty(object):
                     choice, _ = choice
                 self.choice_keys.append(choice)
         self.required = required
+
+        self.exclude_if_empty = exclude_if_empty
         self.exclude_if_none = exclude_if_none
+
         self._validators = validators
         self.verbose_name = verbose_name
         if type_config:
@@ -93,7 +95,11 @@ class JsonProperty(object):
         return self
 
     def exclude(self, value):
-        return self.exclude_if_none and not value
+        if self.exclude_if_none:
+            return not value
+        if self.exclude_if_empty:
+            return self.empty(value)
+        return False
 
     def empty(self, value):
         return value is None

--- a/test/tests.py
+++ b/test/tests.py
@@ -634,6 +634,20 @@ class PropertyTestCase(unittest2.TestCase):
         self.assertEqual(foo.to_json(), {'name': None})
         self.assertEqual(foo._id, None)
 
+    def test_exclude_if_empty(self):
+        class Foo(JsonObject):
+            points = IntegerProperty(exclude_if_empty=True)
+            name = StringProperty()
+
+        foo = Foo()
+        self.assertEqual(foo.to_json(), {'name': None})
+        self.assertEqual(foo.points, None)
+        foo = Foo(points=0)
+        self.assertEqual(dict(foo), {'name': None, 'points': 0})
+        foo.points = None
+        self.assertEqual(foo.to_json(), {'name': None})
+        self.assertEqual(foo.points, None)
+
     def test_descriptor(self):
         class Desc(object):
             def __get__(self, instance, owner):
@@ -669,7 +683,7 @@ class PropertyTestCase(unittest2.TestCase):
         class Foo(JsonObject):
             pass
         foo = Foo()
-        
+
         with self.assertRaises(AttributeError):
             foo.hello
 


### PR DESCRIPTION
Add an exclude_if_empty variable that will exclude from the json dict if the value is None (not falsey).

The exclude_if_null is kept as is to keep backwards compatibility.

Although I think the better way to do all of this would be to pass an exclude_values list or an exclude_func which lets the user pick exactly what he wants to discard.