### PR TITLE
Make dicts ordered.

### DIFF
--- a/jsonobject/containers.py
+++ b/jsonobject/containers.py
@@ -120,6 +120,9 @@ class JsonDict(SimpleDict):
         for key, value in self._obj.items():
             self[key] = self.__wrap(key, value)
 
+    def copy(self):
+        return self.__class__(self._obj, self._wrapper, self._type_config)
+
     def validate(self, required=True):
         for obj in self.values():
             self._wrapper.validate(obj, required=required)

--- a/jsonobject/utils.py
+++ b/jsonobject/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from collections import OrderedDict
 from .exceptions import BadValueError
 
 
@@ -11,7 +12,7 @@ def check_type(obj, item_type, message):
         return obj
 
 
-class SimpleDict(dict):
+class SimpleDict(OrderedDict):
     """
     Re-implements destructive methods of dict
     to use only setitem and getitem and delitem


### PR DESCRIPTION
Json objects are ordered, python dicts are not, which will cause code depending on ordering eg. 
{
 'name': 'joe',
 'surname': 'bloggs'
}

to sometimes output surname first if it just iterated through the key/values.

