### PR TITLE
fix exclude_if_none to do what it should

### DIFF
--- a/jsonobject/base_properties.py
+++ b/jsonobject/base_properties.py
@@ -18,7 +18,7 @@ class JsonProperty(object):
     type_config = None
 
     def __init__(self, default=Ellipsis, name=None, choices=None,
-                 required=False, exclude_if_none=False, validators=None,
+                 required=False, exclude_if_none=True, validators=None,
                  verbose_name=None, type_config=None):
         validators = validators or ()
         self.name = name
@@ -93,7 +93,7 @@ class JsonProperty(object):
         return self
 
     def exclude(self, value):
-        return self.exclude_if_none and not value
+        return self.exclude_if_none and value is None
 
     def empty(self, value):
         return value is None


### PR DESCRIPTION
Great library, but two things I wanted to address in the pull request:
1) Normally wouldn't want null values to be all over the json and would prefer the field to just be absent, so changing the default for exclude_if_none=True
2) fix the exclude function to actually do a None check because I would want a boolean property to print out false.

Thanks!

