### PR TITLE
Add Python version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,12 @@ setup(
     tests_require=['unittest2'],
     ext_modules=extensions,
     test_suite='test',
+    classifiers=(
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
+    ),
 )


### PR DESCRIPTION
Without classifiers it isn't clear which versions of Python are supported, and things like [caniusepython3.com](https://caniusepython3.com/project/jsonobject) will fail.