### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: BSD License',
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     packages=['jsonobject'],
     setup_requires=CYTHON_REQUIRES,
     install_requires=['six'],
-    tests_require=['unittest2'],
     ext_modules=extensions,
     test_suite='test',
     classifiers=(

--- a/test/test_couchdbkit.py
+++ b/test/test_couchdbkit.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
 import os
-from unittest2 import TestCase
+from unittest import TestCase
 from .couchdbkit.application import Application
 from io import open
 

--- a/test/test_stringconversions.py
+++ b/test/test_stringconversions.py
@@ -4,11 +4,11 @@ from decimal import Decimal
 import datetime
 from jsonobject.exceptions import BadValueError
 from jsonobject import JsonObject, ObjectProperty, DateTimeProperty
-import unittest2
+import unittest
 from jsonobject.base import get_settings
 
 
-class StringConversionsTest(unittest2.TestCase):
+class StringConversionsTest(unittest.TestCase):
 
     EXAMPLES = {
         'decimal': '1.2',

--- a/test/tests.py
+++ b/test/tests.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 from copy import deepcopy
-import unittest2
+import unittest
 from jsonobject import *
 from jsonobject.exceptions import (
     BadValueError,
@@ -68,7 +68,7 @@ class ObjectWithDictProperty(JsonObject):
     mapping = DictProperty()
 
 
-class JsonObjectTestCase(unittest2.TestCase):
+class JsonObjectTestCase(unittest.TestCase):
     def _danny_data(self):
         return {
             'first_name': 'Danny',
@@ -434,7 +434,7 @@ class JsonObjectTestCase(unittest2.TestCase):
         self.assertIsInstance(foo.bar, Bar)
 
 
-class PropertyInsideContainerTest(unittest2.TestCase):
+class PropertyInsideContainerTest(unittest.TestCase):
 
     def test_default_is_required(self):
         class Foo(JsonObject):
@@ -466,7 +466,7 @@ class PropertyInsideContainerTest(unittest2.TestCase):
             Foo(container=[None])
 
 
-class LazyValidationTest(unittest2.TestCase):
+class LazyValidationTest(unittest.TestCase):
 
     def _validate_raises(self, foo):
         with self.assertRaises(BadValueError):
@@ -577,7 +577,7 @@ class LazyValidationTest(unittest2.TestCase):
         self._validate_not_raises(foo)
 
 
-class PropertyTestCase(unittest2.TestCase):
+class PropertyTestCase(unittest.TestCase):
     def test_date(self):
         import datetime
         p = DateProperty()
@@ -755,12 +755,12 @@ class PropertyTestCase(unittest2.TestCase):
         class Foo(JsonObject):
             pass
         foo = Foo()
-        
+
         with self.assertRaises(AttributeError):
             foo.hello
 
 
-class DynamicConversionTestCase(unittest2.TestCase):
+class DynamicConversionTestCase(unittest.TestCase):
     import datetime
 
     class Foo(JsonObject):
@@ -843,7 +843,7 @@ class User(JsonObject):
     tags = ListProperty(six.text_type)
 
 
-class TestExactDateTime(unittest2.TestCase):
+class TestExactDateTime(unittest.TestCase):
     def test_exact(self):
         class DateObj(JsonObject):
             date = DateTimeProperty(exact=True)
@@ -862,7 +862,7 @@ class TestExactDateTime(unittest2.TestCase):
         self.assertEqual(len(date_obj.to_json()['date']), 27)
 
 
-class IntegerTest(unittest2.TestCase):
+class IntegerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         class Foo(JsonObject):
@@ -883,7 +883,7 @@ class IntegerTest(unittest2.TestCase):
         self.assertEqual(foo.to_json()['my_int'], 0)
 
 
-class TestReadmeExamples(unittest2.TestCase):
+class TestReadmeExamples(unittest.TestCase):
     def test(self):
         import datetime
         user1 = User(


### PR DESCRIPTION
Fixes #184

This moves away from `unittest2` and then claims support for Python 3.10 (which otherwise appears to already work fine).

`unittest2` appears not to be compatible with Python 3.10[^1], so this is a stepping stone towards getting testing working there.

`unittest2` also appears to be somewhat unmaintained (based on the activity on https://github.com/testing-cabal/unittest-ext), which is somewhat unsurprising given that Python 2 is no longer maintained.

In any case, the built-in `unittest` module seems to have all that's needed here.

[^1]: specifically it relies on various types which have moved out of `collections`.