### PR TITLE
Remove unsupported versions of python (<3.7)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,7 @@ setup(
     test_suite='test',
     classifiers=(
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
These are the current versions of python that are not past their EOL date. https://github.com/dimagi/jsonobject/pull/190 Actually removes them from the bulid while also switching to github actions, and https://github.com/dimagi/jsonobject/pull/186 adds support for 3.10 as well.