### PR TITLE
Automatically rebuild C files using latest Cython

### DIFF
--- a/.github/workflows/rebuild_c_files.yml
+++ b/.github/workflows/rebuild_c_files.yml
@@ -13,6 +13,8 @@ jobs:
           pip install cython
           echo "cython_version=$(pip freeze | grep -i cython | cut -d'=' -f3)" >> $GITHUB_ENV
       - name: Rebuild .c files with latest Cython
+        # From https://github.com/marketplace/actions/create-pr-action:
+        # > executes an arbitrary command and commits the changes to the new pull request
         uses: technote-space/create-pr-action@v2
         with:
           EXECUTE_COMMANDS: |

--- a/.github/workflows/rebuild_c_files.yml
+++ b/.github/workflows/rebuild_c_files.yml
@@ -1,6 +1,4 @@
 on:
-  schedule:
-    - cron: 0 0 * * *
   pull_request:
     types: [opened, synchronize, reopened, closed]
 

--- a/.github/workflows/rebuild_c_files.yml
+++ b/.github/workflows/rebuild_c_files.yml
@@ -1,0 +1,26 @@
+on:
+  schedule:
+    - cron: 0 0 * * *
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+name: Rebuild .c files with latest Cython
+jobs:
+  rebuild_c_files:
+    name: Rebuild .c files with latest Cython
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          pip install cython
+          echo "cython_version=$(pip freeze | grep -i cython | cut -d'=' -f3)" >> $GITHUB_ENV
+      - name: Rebuild .c files with latest Cython
+        uses: technote-space/create-pr-action@v2
+        with:
+          EXECUTE_COMMANDS: |
+            find jsonobject -iname '*.c' -delete
+            find jsonobject -iname '*.so' -delete
+            python setup.py build_ext --inplace
+          COMMIT_MESSAGE: 'Rebuild C files using cython==${{ env.cython_version }}'
+          PR_BRANCH_NAME: 'cython-${{ env.cython_version }}'
+          PR_TITLE: 'Rebuild C files using cython==${{ env.cython_version }}'

--- a/.github/workflows/rebuild_c_files.yml
+++ b/.github/workflows/rebuild_c_files.yml
@@ -1,4 +1,6 @@
 on:
+  schedule:
+    - cron: 0 0 1 * *
   pull_request:
     types: [opened, synchronize, reopened, closed]
 


### PR DESCRIPTION
Fixes https://github.com/dimagi/jsonobject/issues/189

This PR adds a github actions workflow for automatically creating a PR updating C files whenever there's a new ~python~ Cython version. The automation runs on a schedule once a day.

To see how I tested this PR, check https://github.com/dimagi/jsonobject/pull/193. I added a commit to delete the built .c files, and the automation automatically opened a PR into that PR to resolve the diff.