### PR TITLE
Re-add JsonObjectMeta to jsonobject package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,14 @@
 No significant changes since the last release
 
 
+## 2.3.1
+
+| Released on | Released by   |
+|-------------|---------------|
+| 2025-02-27  | @millerdev    |
+
+- Restore `jsonobject.JsonObjectMeta`
+
 ## 2.3.0
 
 | Released on | Released by   |

--- a/jsonobject/__init__.py
+++ b/jsonobject/__init__.py
@@ -3,7 +3,7 @@ from .containers import JsonArray
 from .properties import *
 from .api import JsonObject
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 __all__ = [
     'IntegerProperty', 'FloatProperty', 'DecimalProperty',
     'StringProperty', 'BooleanProperty',

--- a/jsonobject/__init__.py
+++ b/jsonobject/__init__.py
@@ -1,3 +1,4 @@
+from .base import JsonObjectMeta
 from .containers import JsonArray
 from .properties import *
 from .api import JsonObject
@@ -8,5 +9,5 @@ __all__ = [
     'StringProperty', 'BooleanProperty',
     'DateProperty', 'DateTimeProperty', 'TimeProperty',
     'ObjectProperty', 'ListProperty', 'DictProperty', 'SetProperty',
-    'JsonObject', 'JsonArray',
+    'JsonObject', 'JsonObjectMeta', 'JsonArray',
 ]

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import unittest
+import jsonobject
 from jsonobject import *
 from jsonobject.exceptions import (
     BadValueError,
@@ -428,6 +429,10 @@ class JsonObjectTestCase(unittest.TestCase):
 
         foo = Foo()
         self.assertIsInstance(foo.bar, Bar)
+
+    def test_module_has_jsonobjectmeta(self):
+        # regression test
+        self.assertIsInstance(jsonobject.JsonObjectMeta, type)
 
 
 class TestJsonArray(unittest.TestCase):


### PR DESCRIPTION
Removed in ae870841a0a287988c221c01eda828cf634fb5f6, but jsonobject-couchdbkit [references it](https://github.com/dimagi/couchdbkit/blob/1d81c9288ee1535cd521d187cfd258977c7f4663/couchdbkit/schema/base.py#L46).